### PR TITLE
Kg integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ _local
 
 # Dependency directories
 /node_modules
+
+# Local development directories
+/_kg-integration

--- a/web/_data/kg-data/README.md
+++ b/web/_data/kg-data/README.md
@@ -1,0 +1,1 @@
+This is a temporary directory for static `.csv`s of knowledge graph data to fill out 11ty data queries and templates. It will be replaced by a new instance of GraphBD, or an updated version of the Data.world implementation.  

--- a/web/_data/kg-data/method-centrality.csv
+++ b/web/_data/kg-data/method-centrality.csv
@@ -1,0 +1,25 @@
+method,label,centrality
+https://uxmethods.org/method/UsabilityTesting,Usability Testing,9
+https://uxmethods.org/method/DomainModeling,Domain Modeling,7
+https://uxmethods.org/method/TaxonomyDesign,Taxonomy Design,7
+https://uxmethods.org/method/Wireframing,Wireframing,7
+https://uxmethods.org/method/AccessibilityEvaluation,Accessibility Evaluation,6
+https://uxmethods.org/method/JourneyMapping,Journey Mapping,6
+https://uxmethods.org/method/Prototyping,Prototyping,6
+https://uxmethods.org/method/CardSorting,Card Sorting,5
+https://uxmethods.org/method/CategoryDesign,Category Design,5
+https://uxmethods.org/method/FirstClickTesting,First Click Testing,5
+https://uxmethods.org/method/Storyboarding,Storyboarding,5
+https://uxmethods.org/method/UserInterviewing,User Interviewing,5
+https://uxmethods.org/method/A-BTesting,A-B Testing,4
+https://uxmethods.org/method/ContentAuditing,Content Auditing,4
+https://uxmethods.org/method/ContextualInterviewing,Contextual Interviewing,4
+https://uxmethods.org/method/NavigationDesign,Navigation Design,4
+https://uxmethods.org/method/Scenarios,Scenarios,4
+https://uxmethods.org/method/StakeholderInterviewing,Stakeholder Interviewing,4
+https://uxmethods.org/method/TaskAnalysis,Task Analysis,4
+https://uxmethods.org/method/HeuristicEvaluation,Heuristic Evaluation,3
+https://uxmethods.org/method/PersonaCreation,Persona Creation,3
+https://uxmethods.org/method/StyleTileCreation,Style Tile Creation,3
+https://uxmethods.org/method/UseCases,Use Cases,3
+https://uxmethods.org/method/CompetitiveAnalysis,Competitive Analysis,2

--- a/web/_data/kg-data/shared-output.csv
+++ b/web/_data/kg-data/shared-output.csv
@@ -1,0 +1,118 @@
+origin,destination,sharedOutputCount,sharedOutput
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/JourneyMapping,3,"https://uxmethods.org/taxonomy/BusinessGoals, https://uxmethods.org/taxonomy/SuccessMetrics, https://uxmethods.org/taxonomy/UserProfile"
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/Storyboarding,2,"https://uxmethods.org/taxonomy/BusinessGoals, https://uxmethods.org/taxonomy/UserProfile"
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/TaxonomyDesign,2,"https://uxmethods.org/taxonomy/BusinessGoals, https://uxmethods.org/taxonomy/UserProfile"
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/UserInterviewing,2,"https://uxmethods.org/taxonomy/BusinessGoals, https://uxmethods.org/taxonomy/UserProfile"
+https://uxmethods.org/method/DomainModeling,https://uxmethods.org/method/NavigationDesign,2,"https://uxmethods.org/taxonomy/ClassificationModel, https://uxmethods.org/taxonomy/ContentStructure"
+https://uxmethods.org/method/DomainModeling,https://uxmethods.org/method/UsabilityTesting,2,"https://uxmethods.org/taxonomy/ClassificationModel, https://uxmethods.org/taxonomy/NavigationDesign"
+https://uxmethods.org/method/Wireframing,https://uxmethods.org/method/A-BTesting,2,"https://uxmethods.org/taxonomy/ContentStructure, https://uxmethods.org/taxonomy/PageLayoutDesign"
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/Wireframing,2,"https://uxmethods.org/taxonomy/MentalModel, https://uxmethods.org/taxonomy/UserGoals"
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/Wireframing,2,"https://uxmethods.org/taxonomy/MentalModel, https://uxmethods.org/taxonomy/UserGoals"
+https://uxmethods.org/method/CardSorting,https://uxmethods.org/method/CategoryDesign,2,"https://uxmethods.org/taxonomy/MentalModel, https://uxmethods.org/taxonomy/UserPreference"
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/CategoryDesign,2,"https://uxmethods.org/taxonomy/MentalModel, https://uxmethods.org/taxonomy/UserPreference"
+https://uxmethods.org/method/CardSorting,https://uxmethods.org/method/TaxonomyDesign,2,"https://uxmethods.org/taxonomy/MentalModel, https://uxmethods.org/taxonomy/UserPreference"
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/TaxonomyDesign,2,"https://uxmethods.org/taxonomy/MentalModel, https://uxmethods.org/taxonomy/UserPreference"
+https://uxmethods.org/method/Wireframing,https://uxmethods.org/method/AccessibilityEvaluation,2,"https://uxmethods.org/taxonomy/NavigationDesign, https://uxmethods.org/taxonomy/PageLayoutDesign"
+https://uxmethods.org/method/Wireframing,https://uxmethods.org/method/FirstClickTesting,2,"https://uxmethods.org/taxonomy/NavigationDesign, https://uxmethods.org/taxonomy/PageLayoutDesign"
+https://uxmethods.org/method/Wireframing,https://uxmethods.org/method/Prototyping,2,"https://uxmethods.org/taxonomy/NavigationDesign, https://uxmethods.org/taxonomy/PageLayoutDesign"
+https://uxmethods.org/method/Wireframing,https://uxmethods.org/method/UsabilityTesting,2,"https://uxmethods.org/taxonomy/NavigationDesign, https://uxmethods.org/taxonomy/PageLayoutDesign"
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/BusinessGoals
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/DomainModeling,1,https://uxmethods.org/taxonomy/BusinessGoals
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/Prototyping,1,https://uxmethods.org/taxonomy/BusinessGoals
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/BusinessGoals
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/Wireframing,1,https://uxmethods.org/taxonomy/BusinessGoals
+https://uxmethods.org/method/CategoryDesign,https://uxmethods.org/method/NavigationDesign,1,https://uxmethods.org/taxonomy/ClassificationModel
+https://uxmethods.org/method/TaxonomyDesign,https://uxmethods.org/method/NavigationDesign,1,https://uxmethods.org/taxonomy/ClassificationModel
+https://uxmethods.org/method/CategoryDesign,https://uxmethods.org/method/UsabilityTesting,1,https://uxmethods.org/taxonomy/ClassificationModel
+https://uxmethods.org/method/TaxonomyDesign,https://uxmethods.org/method/UsabilityTesting,1,https://uxmethods.org/taxonomy/ClassificationModel
+https://uxmethods.org/method/CategoryDesign,https://uxmethods.org/method/Wireframing,1,https://uxmethods.org/taxonomy/ClassificationModel
+https://uxmethods.org/method/DomainModeling,https://uxmethods.org/method/Wireframing,1,https://uxmethods.org/taxonomy/ClassificationModel
+https://uxmethods.org/method/TaxonomyDesign,https://uxmethods.org/method/Wireframing,1,https://uxmethods.org/taxonomy/ClassificationModel
+https://uxmethods.org/method/StyleTileCreation,https://uxmethods.org/method/AccessibilityEvaluation,1,https://uxmethods.org/taxonomy/ColorPalette
+https://uxmethods.org/method/CompetitiveAnalysis,https://uxmethods.org/method/ContentAuditing,1,https://uxmethods.org/taxonomy/ContentQualityStandard
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/ContentAuditing,1,https://uxmethods.org/taxonomy/ContentQualityStandard
+https://uxmethods.org/method/ContentAuditing,https://uxmethods.org/method/A-BTesting,1,https://uxmethods.org/taxonomy/ContentStructure
+https://uxmethods.org/method/DomainModeling,https://uxmethods.org/method/A-BTesting,1,https://uxmethods.org/taxonomy/ContentStructure
+https://uxmethods.org/method/ContentAuditing,https://uxmethods.org/method/NavigationDesign,1,https://uxmethods.org/taxonomy/ContentStructure
+https://uxmethods.org/method/Wireframing,https://uxmethods.org/method/NavigationDesign,1,https://uxmethods.org/taxonomy/ContentStructure
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/MentalModel
+https://uxmethods.org/method/CardSorting,https://uxmethods.org/method/DomainModeling,1,https://uxmethods.org/taxonomy/MentalModel
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/DomainModeling,1,https://uxmethods.org/taxonomy/MentalModel
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/DomainModeling,1,https://uxmethods.org/taxonomy/MentalModel
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/TaxonomyDesign,1,https://uxmethods.org/taxonomy/MentalModel
+https://uxmethods.org/method/CardSorting,https://uxmethods.org/method/Wireframing,1,https://uxmethods.org/taxonomy/MentalModel
+https://uxmethods.org/method/DomainModeling,https://uxmethods.org/method/AccessibilityEvaluation,1,https://uxmethods.org/taxonomy/NavigationDesign
+https://uxmethods.org/method/NavigationDesign,https://uxmethods.org/method/AccessibilityEvaluation,1,https://uxmethods.org/taxonomy/NavigationDesign
+https://uxmethods.org/method/DomainModeling,https://uxmethods.org/method/FirstClickTesting,1,https://uxmethods.org/taxonomy/NavigationDesign
+https://uxmethods.org/method/NavigationDesign,https://uxmethods.org/method/FirstClickTesting,1,https://uxmethods.org/taxonomy/NavigationDesign
+https://uxmethods.org/method/DomainModeling,https://uxmethods.org/method/Prototyping,1,https://uxmethods.org/taxonomy/NavigationDesign
+https://uxmethods.org/method/NavigationDesign,https://uxmethods.org/method/Prototyping,1,https://uxmethods.org/taxonomy/NavigationDesign
+https://uxmethods.org/method/NavigationDesign,https://uxmethods.org/method/UsabilityTesting,1,https://uxmethods.org/taxonomy/NavigationDesign
+https://uxmethods.org/method/Scenarios,https://uxmethods.org/method/JourneyMapping,1,https://uxmethods.org/taxonomy/SuccessMetrics
+https://uxmethods.org/method/UseCases,https://uxmethods.org/method/JourneyMapping,1,https://uxmethods.org/taxonomy/SuccessMetrics
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/PersonaCreation,1,https://uxmethods.org/taxonomy/UserBehavior
+https://uxmethods.org/method/FirstClickTesting,https://uxmethods.org/method/PersonaCreation,1,https://uxmethods.org/taxonomy/UserBehavior
+https://uxmethods.org/method/JourneyMapping,https://uxmethods.org/method/PersonaCreation,1,https://uxmethods.org/taxonomy/UserBehavior
+https://uxmethods.org/method/Scenarios,https://uxmethods.org/method/PersonaCreation,1,https://uxmethods.org/taxonomy/UserBehavior
+https://uxmethods.org/method/Storyboarding,https://uxmethods.org/method/PersonaCreation,1,https://uxmethods.org/taxonomy/UserBehavior
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/PersonaCreation,1,https://uxmethods.org/taxonomy/UserBehavior
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/CardSorting,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/CardSorting,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/CardSorting,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/CompetitiveAnalysis,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/CompetitiveAnalysis,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/CompetitiveAnalysis,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/ContentAuditing,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/ContentAuditing,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/ContentAuditing,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/JourneyMapping,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/JourneyMapping,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/JourneyMapping,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/NavigationDesign,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/NavigationDesign,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/NavigationDesign,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/Prototyping,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/Prototyping,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/Prototyping,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/Scenarios,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/Scenarios,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/Scenarios,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/Storyboarding,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/Storyboarding,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/Storyboarding,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/UsabilityTesting,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/UsabilityTesting,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/UsabilityTesting,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/UseCases,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/TaskAnalysis,https://uxmethods.org/method/UseCases,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/UseCases,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/Wireframing,1,https://uxmethods.org/taxonomy/UserGoals
+https://uxmethods.org/method/A-BTesting,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/JourneyMapping,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/PersonaCreation,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/Prototyping,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/Storyboarding,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/UsabilityTesting,https://uxmethods.org/method/CategoryDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/A-BTesting,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/CardSorting,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/JourneyMapping,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/PersonaCreation,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/Prototyping,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/Storyboarding,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/UsabilityTesting,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/UserInterviewing,https://uxmethods.org/method/StyleTileCreation,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/A-BTesting,https://uxmethods.org/method/TaxonomyDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/ContextualInterviewing,https://uxmethods.org/method/TaxonomyDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/JourneyMapping,https://uxmethods.org/method/TaxonomyDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/PersonaCreation,https://uxmethods.org/method/TaxonomyDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/Prototyping,https://uxmethods.org/method/TaxonomyDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/Storyboarding,https://uxmethods.org/method/TaxonomyDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/UsabilityTesting,https://uxmethods.org/method/TaxonomyDesign,1,https://uxmethods.org/taxonomy/UserPreference
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/CardSorting,1,https://uxmethods.org/taxonomy/UserProfile
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/ContextualInterviewing,1,https://uxmethods.org/taxonomy/UserProfile
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/PersonaCreation,1,https://uxmethods.org/taxonomy/UserProfile
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/Scenarios,1,https://uxmethods.org/taxonomy/UserProfile
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/TaskAnalysis,1,https://uxmethods.org/taxonomy/UserProfile
+https://uxmethods.org/method/StakeholderInterviewing,https://uxmethods.org/method/UseCases,1,https://uxmethods.org/taxonomy/UserProfile

--- a/web/_data/methods.js
+++ b/web/_data/methods.js
@@ -1,6 +1,8 @@
 import {client} from './utils/sanityClient.js'
 import {toHTML} from '@portabletext/to-html'
 import groq from 'groq'
+import {readFileSync} from 'fs'
+import {join} from 'path'
 
 // Map serializers to Portable Text components
 function prepareMethod(method) {
@@ -11,6 +13,57 @@ function prepareMethod(method) {
     // lede: toHTML(article.lede, { components: afcComponents }),
   }
 }
+
+// ############################################
+
+// filter `methodPreviews` to include only those methods that are a "destination" for which the current method is an "origin" in the sharedOutput.json object
+// add the filtered `methodPreviews` to the current method object as `nextMethods`
+
+
+// load the shared-output.csv 
+const sharedOutputString = readFileSync(join(process.cwd(), '_data/kg-data/shared-output.csv'), 'utf-8')
+
+// load the shared-output.csv as a json object
+const sharedOutput = sharedOutputString.split('\n').map(row => {
+  const [origin, destination, sharedOutputCount] = row.split(',')
+  return {origin, destination, sharedOutputCount}
+})
+
+// output example:
+// {
+//   origin: 'https://uxmethods.org/method/StakeholderInterviewing',
+//   destination: 'https://uxmethods.org/method/JourneyMapping',
+//   sharedOutputCount: '3'
+// },
+
+
+
+//  loop through the methodPreviews object and filter to include only those methods that are among the destination methods fo the provided origin method.
+function getRelatedInputs(uri, sharedOutput) {
+  const relatedInputs = sharedOutput.map(relationship => relationship.origin === uri)
+  return relatedInputs
+}
+
+
+
+function getInputPreviews(methodPreviews, relatedInputs) {
+  const inputPreviews = methodPreviews.filter(method => {
+    return relatedInputs.includes(method.uri)
+  })
+  return inputPreviews
+} 
+
+
+
+function getRelatedMethods(methodPreviews, sharedOutput) {
+  const relatedMethods = methodPreviews.map(output => {
+    return sharedOutput.find(row => row.origin === method.uri && row.destination === output.uri)
+  })
+  return relatedMethods
+}
+
+
+// ############################################
 
 // Fetch methods from Sanity & prepare them for Eleventy
 async function getMethods() {
@@ -32,9 +85,19 @@ async function getMethods() {
       "outcomes": output[]->{
         prefLabel,
         definition,
-      },
+      }, 
     }
   `)
+
+  const methodPreviews = methods.map(method => {
+    return {
+      title: method.title,
+      slug: method.slug,
+      uri: method.uri,
+      metaDescription: method.metaDescription,
+    }
+  })
+  
   const preparedMethods = methods.map(prepareMethod)
   return preparedMethods
 }

--- a/web/_data/methods.js
+++ b/web/_data/methods.js
@@ -4,92 +4,68 @@ import groq from 'groq'
 import {readFileSync} from 'fs'
 import {join} from 'path'
 
-// Map serializers to Portable Text components
-function prepareMethod(method) {
-  return {
-    ...method,
-    overview: toHTML(method.overview),
-    steps: toHTML(method.steps),
-    // lede: toHTML(article.lede, { components: afcComponents }),
-  }
-}
-
-// ############################################
-
-// filter `methodPreviews` to include only those methods that are a "destination" for which the current method is an "origin" in the sharedOutput.json object
-// add the filtered `methodPreviews` to the current method object as `nextMethods`
-
-
-// load the shared-output.csv 
-const sharedOutputString = readFileSync(join(process.cwd(), '_data/kg-data/shared-output.csv'), 'utf-8')
-
-// load the shared-output.csv as a json object
-const sharedOutput = sharedOutputString.split('\n').map(row => {
-  const [origin, destination, sharedOutputCount] = row.split(',')
-  return {origin, destination, sharedOutputCount}
-})
-
-// output example:
-// {
-//   origin: 'https://uxmethods.org/method/StakeholderInterviewing',
-//   destination: 'https://uxmethods.org/method/JourneyMapping',
-//   sharedOutputCount: '3'
-// },
-
-
-
-//  loop through the methodPreviews object and filter to include only those methods that are among the destination methods fo the provided origin method.
-function getRelatedInputs(uri, sharedOutput) {
-  const relatedInputs = sharedOutput.map(relationship => relationship.origin === uri)
-  return relatedInputs
-}
-
-
-
-function getInputPreviews(methodPreviews, relatedInputs) {
-  const inputPreviews = methodPreviews.filter(method => {
-    return relatedInputs.includes(method.uri)
+// Load shared-output.csv
+// This is a stopgap solution until the KG is back online, but we'll use a cached version
+// as a backup going forward which could be something like this.
+const sharedOutput = readFileSync(join(process.cwd(), '_data/kg-data/shared-output.csv'), 'utf-8')
+  .split('\n')
+  .map((row) => {
+    const [origin, destination, sharedOutputCount] = row.split(',')
+    return {origin, destination, sharedOutputCount}
   })
-  return inputPreviews
-} 
 
-
-
-function getRelatedMethods(methodPreviews, sharedOutput) {
-  const relatedMethods = methodPreviews.map(output => {
-    return sharedOutput.find(row => row.origin === method.uri && row.destination === output.uri)
+function prepareMethod(methods, methodPreviews) {
+  const preparedMethods = methods.map((method) => {
+    // Filter and assign methods preview list to previous methods
+    const previousMethods = methodPreviews.filter((methodPreview) => {
+      return sharedOutput.some((relationship) => {
+        return relationship.origin === method.uri && relationship.destination === methodPreview.uri
+      })
+    })
+    // Filter and assign methods preview list to next methods
+    const nextMethods = methodPreviews.filter((methodPreview) => {
+      return sharedOutput.some((relationship) => {
+        return relationship.origin === method.uri && relationship.destination === methodPreview.uri
+      })
+    })
+    // Map serializers to Portable Text components and previous and next lists
+    return {
+      ...method,
+      overview: toHTML(method.overview),
+      steps: toHTML(method.steps),
+      prepareMethods: previousMethods,
+      continueMethods: nextMethods,
+      // lede: toHTML(article.lede, { components: afcComponents }), // reminder for how components are added
+    }
   })
-  return relatedMethods
+  return preparedMethods
 }
-
-
-// ############################################
 
 // Fetch methods from Sanity & prepare them for Eleventy
 async function getMethods() {
   const methods = await client.fetch(groq`
     *[_type == "method"] | order(title) {
-      title,
-      "slug": slug.current,
-      "uri": uri.current,
-      "createdAt": dateStamp.createdAt,
-      "revisedAt": dateStamp.revisedAt,
-      metaDescription,
-      "heroImage": {
-        "caption": heroImage.caption,
-        "altText": heroImage.alt,
-        "url": heroImage.asset->url,
-      },
-      overview,
-      steps,
-      "outcomes": output[]->{
-        prefLabel,
-        definition,
-      }, 
-    }
+        title,
+        "slug": slug.current,
+        "uri": uri.current,
+        "createdAt": dateStamp.createdAt,
+        "revisedAt": dateStamp.revisedAt,
+        metaDescription,
+        "heroImage": {
+          "caption": heroImage.caption,
+          "altText": heroImage.alt,
+          "url": heroImage.asset->url,
+        },
+        overview,
+        steps,
+        "outcomes": output[]->{
+          prefLabel,
+          definition,
+        }, 
+      }
   `)
-
-  const methodPreviews = methods.map(method => {
+  // Prepare previews of all methods for previous and next methods sections
+  const methodPreviews = methods.map((method) => {
     return {
       title: method.title,
       slug: method.slug,
@@ -97,8 +73,7 @@ async function getMethods() {
       metaDescription: method.metaDescription,
     }
   })
-  
-  const preparedMethods = methods.map(prepareMethod)
+  const preparedMethods = prepareMethod(methods, methodPreviews)
   return preparedMethods
 }
 

--- a/web/_data/methods.js
+++ b/web/_data/methods.js
@@ -64,6 +64,12 @@ async function getMethods() {
           prefLabel,
           definition,
         }, 
+        "resources": *[_type == "resource" && references(^._id)]{
+          title,
+          author,
+          resourceUrl,
+          "publisher": publisher.pubName
+        }
       }
   `)
   // Prepare previews of all methods for previous and next methods sections

--- a/web/_data/methods.js
+++ b/web/_data/methods.js
@@ -17,12 +17,14 @@ const sharedOutput = readFileSync(join(process.cwd(), '_data/kg-data/shared-outp
 function prepareMethod(methods, methodPreviews) {
   const preparedMethods = methods.map((method) => {
     // Filter and assign methods preview list to previous methods
+    // TODO: mapping is not yet weighted to prioritize strongest connections
     const previousMethods = methodPreviews.filter((methodPreview) => {
       return sharedOutput.some((relationship) => {
-        return relationship.origin === method.uri && relationship.destination === methodPreview.uri
+        return relationship.destination === method.uri && relationship.origin === methodPreview.uri
       })
     })
     // Filter and assign methods preview list to next methods
+    // TODO: mapping is not yet weighted to prioritize strongest connections
     const nextMethods = methodPreviews.filter((methodPreview) => {
       return sharedOutput.some((relationship) => {
         return relationship.origin === method.uri && relationship.destination === methodPreview.uri

--- a/web/_src/method.njk
+++ b/web/_src/method.njk
@@ -43,8 +43,14 @@ permalink: /method/{{ method.slug | slug }}/index.html
   </section>
   <section>  
     <h2>Resources</h2>
-    {# FPO: method resources (external links) #}
-    <p>FPO</p>
+    <ul>    
+      {% for resource in method.resources.slice(0,6) %}
+        <li>
+          <a href="{{ resource.resourceUrl }}">{{ resource.title }}</a>
+          <p>{{ resource.author }} | {{ resource.publisher }}</p>
+        </li>
+      {% endfor %}
+    </ul>
   </section>
   <section>  
     <h2>Next Steps</h2>

--- a/web/_src/method.njk
+++ b/web/_src/method.njk
@@ -16,8 +16,14 @@ permalink: /method/{{ method.slug | slug }}/index.html
   </section>
   <section>  
     <h2>Preparation</h2>
-    {# FPO: method inputs #}
-    <p>FPO</p>
+    <ul>    
+      {% for method in method.prepareMethods.slice(0,6) %}
+        <li>
+          <a href="/method/{{ method.slug | slug }}/">{{ method.title }}</a>
+          <p>{{ method.metaDescription }}</p>
+        </li>
+      {% endfor %}
+    </ul>
   </section>
   <section>
     <h2>Steps</h2>
@@ -42,8 +48,14 @@ permalink: /method/{{ method.slug | slug }}/index.html
   </section>
   <section>  
     <h2>Next Steps</h2>
-    {# FPO: method next methods #}
-    <p>FPO</p>
+    <ul>    
+      {% for method in method.continueMethods.slice(0,6) %}
+        <li>
+          <a href="/method/{{ method.slug | slug }}/">{{ method.title }}</a>
+          <p>{{ method.metaDescription }}</p>
+        </li>
+      {% endfor %}
+    </ul>
   </section>
   <section>  
     <h2>References</h2>


### PR DESCRIPTION
This PR adds in references to a static export from the existing knowledge graph that allows us to map "preparation" and "next steps" to methods in our new templates. This gives us the primary data elements for Methods page types so that we can move the UX and UI design forward with actual content. I also added external reference links in. 
